### PR TITLE
make sure to spawn entities of MOD

### DIFF
--- a/19/src/main/java/mobi/omegacentauri/raspberryjammod/APIHandler.java
+++ b/19/src/main/java/mobi/omegacentauri/raspberryjammod/APIHandler.java
@@ -904,7 +904,7 @@ public class APIHandler {
 	}
     
     protected String rename111(String entityId) {
-        if (entityId.startsWith("minecraft:"))
+        if (entityId.contains(":"))
             return entityId;
         System.out.println("Searching for "+entityId);
         String e = entityId.toLowerCase();


### PR DESCRIPTION
The original implementation has the bug that fails to spawn entities of MOD. For example, if I try to spawn the entity of MOD `my_mod:my_entity`, `rename111` method returns ID `minecraft:my_mod:my_entity` and fail to do. So, I treat entity IDs of MOD that contains `:` as special.