### PR TITLE
Python 3 Compatibility for Vec3

### DIFF
--- a/mcpipy/mcpi/vec3.py
+++ b/mcpipy/mcpi/vec3.py
@@ -71,22 +71,10 @@ class Vec3:
     
     #Python 3 Comparisons
     def __eq__(self, rhs):
-        dx = self.x - rhs.x
-        if dx != 0: return False
-        dy = self.y - rhs.y
-        if dy != 0: return False
-        dz = self.z - rhs.z
-        if dz != 0: return False
-        return True
+        return self.x == rhs.x and self.y == rhs.y and self.z == rhs.z
 
     def __ne__(self, rhs):
-        dx = self.x - rhs.x
-        if dx != 0: return True
-        dy = self.y - rhs.y
-        if dy != 0: return True
-        dz = self.z - rhs.z
-        if dz != 0: return True
-        return False
+        return self.x != rhs.x or self.y != rhs.y or self.z != rhs.z
 
     def iround(self): self._map(lambda v:int(v+0.5))
     def ifloor(self): self._map(int)

--- a/mcpipy/mcpi/vec3.py
+++ b/mcpipy/mcpi/vec3.py
@@ -68,6 +68,25 @@ class Vec3:
         dz = self.z - rhs.z
         if dz != 0: return dz
         return 0
+    
+    #Python 3 Comparisons
+    def __eq__(self, rhs):
+        dx = self.x - rhs.x
+        if dx != 0: return False
+        dy = self.y - rhs.y
+        if dy != 0: return False
+        dz = self.z - rhs.z
+        if dz != 0: return False
+        return True
+
+    def __ne__(self, rhs):
+        dx = self.x - rhs.x
+        if dx != 0: return True
+        dy = self.y - rhs.y
+        if dy != 0: return True
+        dz = self.z - rhs.z
+        if dz != 0: return True
+        return False
 
     def iround(self): self._map(lambda v:int(v+0.5))
     def ifloor(self): self._map(int)


### PR DESCRIPTION
This commit adds the ``__eq__`` and ``__ne__`` functions to the Vec3 class, enabling equal and not equal comparisons of the class in Python 3. Discussion should be had on support for ``__gt__``, ``__lt__``, ``__ge__``, and ``__le__``.