### PR TITLE
Use collections.abc.Iterable for type checking and flattenning

### DIFF
--- a/mcpipy/mcpi/util.py
+++ b/mcpipy/mcpi/util.py
@@ -9,7 +9,7 @@ except NameError:
 
 def flatten(l):
     for e in l:
-        if isinstance(e, collections.Iterable) and not isinstance(e, basestring):
+        if isinstance(e, collections.abc.Iterable) and not isinstance(e, basestring):
             for ee in flatten(e): yield ee
         else: yield e
 

--- a/mcpipy/mcpi/vec3.py
+++ b/mcpipy/mcpi/vec3.py
@@ -2,7 +2,7 @@ import collections
 
 class Vec3:
     def __init__(self, x=0, y=0, z=0):
-        if isinstance(x, collections.Iterable):
+        if isinstance(x, collections.abc.Iterable):
             self.x, self.y, self.z = tuple(x)
         else:
             self.x = x


### PR DESCRIPTION
In Python 3.3, the collections.Iterable class was moved into its own module

Instead, now test the Abstract Base Class Iterable type.

https://docs.python.org/3/library/collections.abc.html

This fixes the error `module 'collections' has not attribute 'Iterable'` when calling
methods such as `minecraft.postToChat()` 

Fixes #68 