### PR TITLE
Fixed a bug in util.py

### DIFF
--- a/mcpipy/mcpi/util.py
+++ b/mcpipy/mcpi/util.py
@@ -6,6 +6,10 @@ try:
     basestring
 except NameError:
     basestring = str  # compatibility for Python 3
+try:
+    collections.Iterable
+except AttributeError:
+    collections.Iterable = collections.abc.Iterable
 
 def flatten(l):
     for e in l:


### PR DESCRIPTION
In Python 3.10, `collections.Iterable` has been moved to `collections.abc.Iterable`. Add compatibility for this change.